### PR TITLE
checkpoint: confirm affect in pdk with offset check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           pip3 install .
           popd
 
-          extism install latest
+          extism install git
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -52,4 +52,7 @@ jobs:
 
       - name: Test example
         run: |
-          extism call --input "this is a test" example.wasm count_vowels | grep "4"
+          TEST=$(extism call example.wasm --input "this is a test" --set-config='{"thing": "1", "a": "b"}' count_vowels)
+          echo $TEST | grep '"count": 4'
+          echo $TEST | grep '"config": "1"'
+          echo $TEST | grep '"a": "this is var a"'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+example:
+	npx asc example.ts --outFile example.wasm --use abort=example/myAbort

--- a/example.ts
+++ b/example.ts
@@ -1,4 +1,4 @@
-import { Host } from './lib/sdk';
+import { Host } from './lib/pdk';
 
 function myAbort(
   message: string | null,
@@ -27,11 +27,13 @@ export function count_vowels(): i32 {
   const vars = host.vars()
 
   var a = Uint8Array.wrap(String.UTF8.encode("this is var a"))
-  vars.set('a', a);
+  // vars.set('a', a);
+  const data = vars.get('a');
+  const thing = host.config("thing");
 
-  const data = vars.get('a')
 
-  var out = '{"count": ' + count.toString() + ', "a": "' + String.UTF8.decode(data.buffer) + '"}';
+
+  var out = '{"count": ' + count.toString() + ', "config": "' + thing + '"}';
   host.outputString(out);
 
   vars.remove('a');

--- a/example.ts
+++ b/example.ts
@@ -27,11 +27,12 @@ export function count_vowels(): i32 {
   const vars = host.vars()
 
   var a = Uint8Array.wrap(String.UTF8.encode("this is var a"))
-  // vars.set('a', a);
+  vars.set('a', a);
   const thing = host.config("thing");
-  const data = vars.get('a');
+  let data = vars.get('a');
+  let var_a = (data == null) ? "null" : String.UTF8.decode(data.buffer);
 
-  var out = '{"count": ' + count.toString() + ', "config": "' + (thing == null ? "null" : thing) + '"}';
+  var out = '{"count": ' + count.toString() + ', "config": "' + (thing == null ? "null" : thing) + '", "a": "' + var_a + '"}';
   host.outputString(out);
 
   vars.remove('a');

--- a/example.ts
+++ b/example.ts
@@ -31,7 +31,7 @@ export function count_vowels(): i32 {
   const thing = host.config("thing");
   const data = vars.get('a');
 
-  var out = '{"count": ' + count.toString() + ', "config": "' + thing + '"}';
+  var out = '{"count": ' + count.toString() + ', "config": "' + (thing == null ? "null" : thing) + '"}';
   host.outputString(out);
 
   vars.remove('a');

--- a/example.ts
+++ b/example.ts
@@ -28,10 +28,8 @@ export function count_vowels(): i32 {
 
   var a = Uint8Array.wrap(String.UTF8.encode("this is var a"))
   // vars.set('a', a);
-  const data = vars.get('a');
   const thing = host.config("thing");
-
-
+  const data = vars.get('a');
 
   var out = '{"count": ' + count.toString() + ', "config": "' + thing + '"}';
   host.outputString(out);

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/sdk';
+export * from './lib/pdk';

--- a/lib/pdk.ts
+++ b/lib/pdk.ts
@@ -24,16 +24,16 @@ export class Variables {
     this.host = host
   }
 
-  get(key: string): Uint8Array {
+  get(key: string): Uint8Array | null {
     const mem = this.host.allocateString(key)
     const offset = extism_var_get(mem.offset)
     if (offset == 0) {
-      return new Uint8Array(0)
+      return null;
     }
 
     const length = extism_length(offset)
     if (length == 0) {
-      return new Uint8Array(0)
+      return null;
     }
 
     let value: Uint8Array = new Uint8Array(u32(length))
@@ -137,17 +137,17 @@ export class Host {
     extism_output_set(offset, length)
   }
 
-  config(key: string): string {
+  config(key: string): string | null {
     const mem = this.allocateString(key)
 
     const offset = extism_config_get(mem.offset)
     if (offset == 0) {
-      return ""
+      return null
     }
 
     const length = extism_length(offset)
     if (length == 0) {
-      return ""
+      return null
     }
 
     let buffer: ArrayBuffer = new ArrayBuffer(u32(length));

--- a/lib/pdk.ts
+++ b/lib/pdk.ts
@@ -27,8 +27,12 @@ export class Variables {
   get(key: string): Uint8Array {
     const mem = this.host.allocateString(key)
     const offset = extism_var_get(mem.offset)
+    if (offset == 0) {
+      return new Uint8Array(0)
+    }
+
     const length = extism_length(offset)
-    if (offset == 0 || length == 0) {
+    if (length == 0) {
       return new Uint8Array(0)
     }
 
@@ -137,8 +141,12 @@ export class Host {
     const mem = this.allocateString(key)
 
     const offset = extism_config_get(mem.offset)
+    if (offset == 0) {
+      return ""
+    }
+
     const length = extism_length(offset)
-    if (offset == 0 || length == 0) {
+    if (length == 0) {
       return ""
     }
 

--- a/lib/pdk.ts
+++ b/lib/pdk.ts
@@ -107,20 +107,18 @@ export class Host {
     return this.allocateBytes(bytes)
   }
 
-  input(): Array<u8> {
-    let dest = new Array<u8>(u32(this.input_length))
+  input(): Uint8Array {
+    let bytes = new Uint8Array(i32(this.input_length));
 
     for (let i = u32(0); i < u32(this.input_length); i++) {
-      dest[i] = u8(extism_load_u8(u32(this.input_offset) + i))
+      bytes[i] = u8(extism_load_u8(u32(this.input_offset) + i))
     }
 
-    return dest
+    return bytes
   }
 
   inputString(): string {
-    return String.fromCharCodes(
-      this.input().map<i32>((value, _index, _self) => i32(value))
-    )
+    return String.UTF8.decode(this.input().buffer)
   }
 
   outputString(s: string): void {


### PR DESCRIPTION
@zshipko - I've updated and tested the pdk such that `config` (and `Variables.get` for that matter) do an offset check before getting the lengt

```typescript
 config(key: string): string {
    const mem = this.allocateString(key)

    const offset = extism_config_get(mem.offset)
    if (offset == 0) {
      return ""
    }

    const length = extism_length(offset)
    if (length == 0) {
      return ""
    }

    let buffer: ArrayBuffer = new ArrayBuffer(u32(length));
    let value: Uint8Array = Uint8Array.wrap(buffer)
    load(offset, value)
    return String.UTF8.decode(buffer)
  }
```

I don't see any difference from this change after reproducing the error, which is:
`extism::sdk ERROR 2022-09-09T14:13:50.285141-06:00 (runtime/src/sdk.rs:162) - Call: Invalid config key`

I will take a look in `runtime/src/sdk.rs`, but wanted to keep you on the same page in case you had any ideas. Thanks!