### PR TITLE
ci: revert to extism cli install latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           pip3 install .
           popd
 
-          extism install git
+          extism install latest
 
       - name: Install Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Switched to use `git` as source of extism installation to test against unreleased changes.

**Wait to merge this until a new `extism/extism` release is cut.**